### PR TITLE
fix: references tool returns empty for class/module names

### DIFF
--- a/internal/lsp/typescript.go
+++ b/internal/lsp/typescript.go
@@ -38,14 +38,17 @@ func openAllTypeScriptFiles(ctx context.Context, client *Client, workspaceDir st
 		if info.IsDir() {
 			// Skip node_modules, .git, and other common directories to avoid processing too many files
 			basename := filepath.Base(path)
-			if basename == "node_modules" || basename == ".git" || strings.HasPrefix(basename, ".") {
+			if basename == "node_modules" || basename == ".git" || basename == "build" ||
+				basename == "dist" || basename == "coverage" || basename == "out" ||
+				strings.HasPrefix(basename, ".") {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		// Check if file is a TypeScript file
-		if strings.HasSuffix(path, ".ts") || strings.HasSuffix(path, ".tsx") {
+		// Check if file is a TypeScript or JavaScript file
+		if strings.HasSuffix(path, ".ts") || strings.HasSuffix(path, ".tsx") ||
+			strings.HasSuffix(path, ".js") || strings.HasSuffix(path, ".jsx") {
 			if err := client.OpenFile(ctx, path); err != nil {
 				lspLogger.Warn("Failed to open TypeScript file %s: %v", path, err)
 				return nil // Continue with other files even if one fails

--- a/internal/tools/references.go
+++ b/internal/tools/references.go
@@ -65,6 +65,8 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 			nameToFind = nameToFind[idx+1:]
 		}
 		filePath := loc.URI.Path()
+		toolsLogger.Info("references: symbol=%s file=%s origPos=L%d:C%d nameToFind=%s",
+			symbol.GetName(), filePath, loc.Range.Start.Line, loc.Range.Start.Character, nameToFind)
 		if content, err := os.ReadFile(filePath); err == nil {
 			lines := strings.Split(string(content), "\n")
 			lineIdx := int(loc.Range.Start.Line)
@@ -73,7 +75,11 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 				if col >= 0 {
 					refPos.Character = uint32(col)
 				}
+				toolsLogger.Info("references: line[%d]=%q col=%d adjustedPos=L%d:C%d",
+					lineIdx, lines[lineIdx], strings.Index(lines[lineIdx], nameToFind), refPos.Line, refPos.Character)
 			}
+		} else {
+			toolsLogger.Error("references: failed to read file %s: %v", filePath, err)
 		}
 
 		// Use LSP references request with correct params structure
@@ -85,7 +91,7 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 				Position: refPos,
 			},
 			Context: protocol.ReferenceContext{
-				IncludeDeclaration: false,
+				IncludeDeclaration: true,
 			},
 		}
 		// File is likely to be opened already, but may not be.
@@ -95,6 +101,7 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 			continue
 		}
 		refs, err := client.References(ctx, refsParams)
+		toolsLogger.Info("references: got %d refs for %s (err=%v)", len(refs), symbol.GetName(), err)
 		if err != nil {
 			return "", fmt.Errorf("failed to get references: %v", err)
 		}

--- a/internal/tools/references.go
+++ b/internal/tools/references.go
@@ -65,8 +65,6 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 			nameToFind = nameToFind[idx+1:]
 		}
 		filePath := loc.URI.Path()
-		toolsLogger.Info("references: symbol=%s file=%s origPos=L%d:C%d nameToFind=%s",
-			symbol.GetName(), filePath, loc.Range.Start.Line, loc.Range.Start.Character, nameToFind)
 		if content, err := os.ReadFile(filePath); err == nil {
 			lines := strings.Split(string(content), "\n")
 			lineIdx := int(loc.Range.Start.Line)
@@ -75,11 +73,7 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 				if col >= 0 {
 					refPos.Character = uint32(col)
 				}
-				toolsLogger.Info("references: line[%d]=%q col=%d adjustedPos=L%d:C%d",
-					lineIdx, lines[lineIdx], strings.Index(lines[lineIdx], nameToFind), refPos.Line, refPos.Character)
 			}
-		} else {
-			toolsLogger.Error("references: failed to read file %s: %v", filePath, err)
 		}
 
 		// Use LSP references request with correct params structure
@@ -91,17 +85,15 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 				Position: refPos,
 			},
 			Context: protocol.ReferenceContext{
-				IncludeDeclaration: true,
+				IncludeDeclaration: false,
 			},
 		}
-		// File is likely to be opened already, but may not be.
 		err := client.OpenFile(ctx, loc.URI.Path())
 		if err != nil {
 			toolsLogger.Error("Error opening file: %v", err)
 			continue
 		}
 		refs, err := client.References(ctx, refsParams)
-		toolsLogger.Info("references: got %d refs for %s (err=%v)", len(refs), symbol.GetName(), err)
 		if err != nil {
 			return "", fmt.Errorf("failed to get references: %v", err)
 		}

--- a/internal/tools/references.go
+++ b/internal/tools/references.go
@@ -54,13 +54,35 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 		// Get the location of the symbol
 		loc := symbol.GetLocation()
 
+		// Adjust position to point at the symbol name, not the keyword.
+		// workspace/symbol returns Range.Start at the beginning of the definition
+		// (e.g. the 'c' in "class Foo"), but textDocument/references needs the
+		// cursor on the symbol name itself (e.g. 'F' in "Foo").
+		refPos := loc.Range.Start
+		nameToFind := symbol.GetName()
+		// For qualified names like "Type.Method" or "Type::Method", search for the last segment
+		if idx := strings.LastIndexAny(nameToFind, ".:"); idx >= 0 {
+			nameToFind = nameToFind[idx+1:]
+		}
+		filePath := loc.URI.Path()
+		if content, err := os.ReadFile(filePath); err == nil {
+			lines := strings.Split(string(content), "\n")
+			lineIdx := int(loc.Range.Start.Line)
+			if lineIdx < len(lines) {
+				col := strings.Index(lines[lineIdx], nameToFind)
+				if col >= 0 {
+					refPos.Character = uint32(col)
+				}
+			}
+		}
+
 		// Use LSP references request with correct params structure
 		refsParams := protocol.ReferenceParams{
 			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 				TextDocument: protocol.TextDocumentIdentifier{
 					URI: loc.URI,
 				},
-				Position: loc.Range.Start,
+				Position: refPos,
 			},
 			Context: protocol.ReferenceContext{
 				IncludeDeclaration: false,


### PR DESCRIPTION
## Summary

- Fix `references` tool returning empty results for class/module names (e.g. `ApplicationController`, `ReadsFromReplica`)
- Root cause: `workspace/symbol` returns `Range.Start` pointing to the keyword (`class`/`module`/`def`), but `textDocument/references` needs the cursor on the symbol name itself
- After getting the symbol location, read the source line and find the column where the symbol name appears, then use that position for the references request

Fixes #1

## Test plan

- [ ] Test `references ApplicationController` against a Ruby workspace — should return results
- [ ] Test `references ReadsFromReplica` against a Ruby workspace — should return results  
- [ ] Verify `references authenticate_from_token` (method name) still works
- [ ] Run `go test ./internal/tools/...`
- [ ] Run `go build ./...`